### PR TITLE
enhancements for notification logic

### DIFF
--- a/src/Controller/EventRegistrationReminderController.php
+++ b/src/Controller/EventRegistrationReminderController.php
@@ -137,10 +137,19 @@ class EventRegistrationReminderController extends AbstractController
 
                         if (!empty($arr) && \is_array($arr)) {
                             $userName = $this->connection->fetchOne('SELECT name FROM tl_user WHERE id = ?', [$userId]);
+                            
+                            $addedOn = $this->connection->fetchOne('SELECT addedOn FROM tl_event_registration_reminder_notification WHERE user = ? AND calendar = ?', [$userId, $calendarId]);
+                            if (false === $addedOn || '' === $addedOn) {
+                                $addedOn = time();
+                            } elseif ((time() - (int) $addedOn) > (15 /* days */ * 86400)) {
+                                $addedOn = time();  // resets addedOn time after longer period without any notification sent to user
+                            } else {
+                                // do not update addedOn time to see since when the user has received notifications
+                            }
 
                             $set = [
                                 'tstamp' => time(),
-                                'addedOn' => time(),
+                                'addedOn' => $addedOn,
                                 'title' => 'Sent a reminder to '.$userName.'.',
                                 'user' => $userId,
                                 'calendar' => $calendarId,

--- a/src/Controller/EventRegistrationReminderController.php
+++ b/src/Controller/EventRegistrationReminderController.php
@@ -139,7 +139,7 @@ class EventRegistrationReminderController extends AbstractController
                             $userName = $this->connection->fetchOne('SELECT name FROM tl_user WHERE id = ?', [$userId]);
                             
                             $addedOn = $this->connection->fetchOne('SELECT addedOn FROM tl_event_registration_reminder_notification WHERE user = ? AND calendar = ?', [$userId, $calendarId]);
-                            if (false === $addedOn || '' === $addedOn) {
+                            if (false === $addedOn || '' === $addedOn || 0 == $addedOn) {
                                 $addedOn = time();
                             } elseif ((time() - (int) $addedOn) > (15 /* days */ * 86400)) {
                                 $addedOn = time();  // resets addedOn time after longer period without any notification sent to user

--- a/src/Controller/EventRegistrationReminderController.php
+++ b/src/Controller/EventRegistrationReminderController.php
@@ -150,7 +150,7 @@ class EventRegistrationReminderController extends AbstractController
                             $set = [
                                 'tstamp' => time(),
                                 'addedOn' => $addedOn,
-                                'title' => 'Sent a reminder to '.$userName.'.',
+                                'title' => 'Sent a reminder to '.$userName.' (since '.date("d.m.Y", $addedOn).').',
                                 'user' => $userId,
                                 'calendar' => $calendarId,
                             ];

--- a/src/Notification/NotificationGenerator.php
+++ b/src/Notification/NotificationGenerator.php
@@ -98,7 +98,11 @@ class NotificationGenerator
                         continue;
                     }
 
-                    $daysRegistered = floor((time() - (int) $registration->addedOn) / 86400);
+                    $elapsedSeconds = time() - (int) $registration->addedOn + 120 /* approx. processing time of all events [s] */;
+                    if ($elapsedSeconds < 0) {
+                        $elapsedSeconds = 0;
+                    }
+                    $daysRegistered = floor($elapsedSeconds / 86400);
 
                     $rowEvent['registrations_'.$deadlineKey][] = [
                         'firstname' => $registration->firstname,

--- a/src/Notification/NotificationGenerator.php
+++ b/src/Notification/NotificationGenerator.php
@@ -71,6 +71,7 @@ class NotificationGenerator
     private function prepareTwigData(): array
     {
         $arrData = [];
+        $currentTime = time() + 60 /* for rounding issues [s] */;  // Use predictive time of processing start
 
         $calendarEventsModelAdapter = $this->framework->getAdapter(CalendarEventsModel::class);
 
@@ -98,7 +99,7 @@ class NotificationGenerator
                         continue;
                     }
 
-                    $elapsedSeconds = time() - (int) $registration->addedOn + 120 /* approx. processing time of all events [s] */;
+                    $elapsedSeconds = $currentTime - (int) $registration->addedOn;
                     if ($elapsedSeconds < 0) {
                         $elapsedSeconds = 0;
                     }

--- a/src/Notification/NotificationGenerator.php
+++ b/src/Notification/NotificationGenerator.php
@@ -98,7 +98,7 @@ class NotificationGenerator
                         continue;
                     }
 
-                    $elapsedSeconds = time() - (int) $registration->addedOn + 120 /* approx. processing time of all events [s] */;
+                    $elapsedSeconds = time() - (int) $registration->tstamp + 120 /* approx. processing time of all events [s] */;
                     if ($elapsedSeconds < 0) {
                         $elapsedSeconds = 0;
                     }

--- a/src/Notification/NotificationGenerator.php
+++ b/src/Notification/NotificationGenerator.php
@@ -98,7 +98,7 @@ class NotificationGenerator
                         continue;
                     }
 
-                    $elapsedSeconds = time() - (int) $registration->tstamp + 120 /* approx. processing time of all events [s] */;
+                    $elapsedSeconds = time() - (int) $registration->addedOn + 120 /* approx. processing time of all events [s] */;
                     if ($elapsedSeconds < 0) {
                         $elapsedSeconds = 0;
                     }

--- a/src/Resources/contao/dca/tl_event_registration_reminder_notification.php
+++ b/src/Resources/contao/dca/tl_event_registration_reminder_notification.php
@@ -29,7 +29,7 @@ $GLOBALS['TL_DCA']['tl_event_registration_reminder_notification'] = [
             'fields' => ['title'],
             'flag' => 1,
             'panelLayout' => 'filter;sort,search,limit',
-            'fields' => ['addedOn DESC'],
+            'fields' => ['tstamp DESC'],
         ],
         'label' => [
             'fields' => ['title'],


### PR DESCRIPTION
- fix: consider processing time in daysRegistered to send the reminder always after same repetition period e.g. 7 days (not 7 days + 1 hour every cycle)
- feat: only update tstamp every time and update addedOn only the first time in order to see since when the user has received notifications

@markocupic What to you think about those enhancements? Do you agree or disagree?

Is everything properly implemented (I can't run it...)? 
Is it possible to test it first on your test environment? 

Thank you.